### PR TITLE
 Prevent unsecure symlink following

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -53,6 +53,11 @@ pub fn build_app() -> App<'static, 'static> {
         .long("no-ignore")
         .help("Don't respect gitignore file");
 
+    let arg_follow_links = Arg::with_name("follow-links")
+        .short("L")
+        .long("--follow-links")
+        .help("Follow symlinks outside current serving base path");
+
     app_from_crate!()
         .about(ABOUT)
         .arg(arg_address)
@@ -63,4 +68,5 @@ pub fn build_app() -> App<'static, 'static> {
         .arg(arg_unzipped)
         .arg(arg_all)
         .arg(arg_no_ignore)
+        .arg(arg_follow_links)
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -22,6 +22,7 @@ pub struct Args {
     pub path: PathBuf,
     pub all: bool,
     pub ignore: bool,
+    pub follow_links: bool,
 }
 
 impl Default for Args {
@@ -35,6 +36,7 @@ impl Default for Args {
             path: env::current_dir().unwrap_or_default(),
             all: false,
             ignore: true,
+            follow_links: false,
         }
     }
 }
@@ -64,6 +66,7 @@ impl Args {
         let compress = !matches.is_present("unzipped");
         let all = matches.is_present("all");
         let ignore = !matches.is_present("no-ignore");
+        let follow_links = matches.is_present("follow-links");
 
         Args {
             address,
@@ -74,6 +77,7 @@ impl Args {
             compress,
             all,
             ignore,
+            follow_links,
             ..Default::default()
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,6 @@ fn main() {
     let app = build_app();
     let args = Args::parse(app.get_matches());
 
-    println!("Files serve on http://{}", args.address());
+    println!("Files served on http://{}", args.address());
     serve(args);
 }

--- a/src/server/extensions.rs
+++ b/src/server/extensions.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2018 Weihang Lo
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+use hyper::mime::{self, Mime};
+use mime_guess::guess_mime_type_opt;
+
+pub trait PathExt {
+    fn mime(&self) -> Option<Mime>;
+    fn is_hidden(&self) -> bool;
+    fn mtime(&self) -> SystemTime;
+    fn filename_str(&self) -> &str;
+    fn size(&self) -> u64;
+}
+
+impl PathExt for Path {
+    /// Guess MIME type from a path.
+    fn mime(&self) -> Option<Mime> {
+        guess_mime_type_opt(&self)
+    }
+
+    /// Check if path is hidden.
+    fn is_hidden(&self) -> bool {
+        self.file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.starts_with("."))
+            .unwrap_or(false)
+    }
+
+    /// Get modified time from a path.
+    fn mtime(&self) -> SystemTime {
+        self.metadata()
+            .and_then(|meta| meta.modified())
+            .unwrap()
+    }
+
+    /// Get file size from a path.
+    fn size(&self) -> u64 {
+        self.metadata()
+            .map(|meta| meta.len())
+            .unwrap_or_default()
+    }
+
+    /// Get a filename `String` from a path.
+    fn filename_str(&self) -> &str {
+        self.file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+    }
+}
+
+pub trait SystemTimeExt {
+    fn timestamp_sec(&self) -> u64;
+}
+
+impl SystemTimeExt for SystemTime {
+    /// Convert `SystemTime` to timestamp in seconds.
+    fn timestamp_sec(&self) -> u64 {
+        self.duration_since(::std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+}
+
+pub trait MimeExt {
+    fn is_media(&self) -> bool;
+}
+
+impl MimeExt for Mime {
+    /// Detect if MIME type is `video/*` or `audio/*`
+    fn is_media(&self) -> bool {
+        match self.type_() {
+            mime::VIDEO | mime::AUDIO  => true,
+            _ => false,
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod t {
+    use super::*;
+
+    #[test]
+    fn mime_is_media() {
+        assert!("video/*".parse::<mime::Mime>().unwrap().is_media());
+        assert!("audio/*".parse::<mime::Mime>().unwrap().is_media());
+        assert!(!"text/*".parse::<mime::Mime>().unwrap().is_media());
+    }
+}

--- a/src/server/index.html
+++ b/src/server/index.html
@@ -23,10 +23,14 @@
       {% for file in files %}
         <li>
           <div>
-          {% if file.is_file %}
-            <svg height="16" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"></path></svg>
-          {% else %}
+          {% if file.path_type == "Dir" %}
             <svg height="16" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M13 4H7V3c0-.66-.31-1-1-1H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1zM6 4H1V3h5v1z"></path></svg>
+          {% elif file.path_type == "File" %}
+            <svg height="16" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M6 5H2V4h4v1zM2 8h7V7H2v1zm0 2h7V9H2v1zm0 2h7v-1H2v1zm10-7.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v12h10V5z"></path></svg>
+          {% elif file.path_type ==  "SymlinkDir" %}
+            <svg height="16" viewBox="0 0 14 16" width="14"><path fill-rule="evenodd" d="M13 4H7V3c0-.66-.31-1-1-1H1c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1zM1 3h5v1H1V3zm6 9v-2c-.98-.02-1.84.22-2.55.7-.71.48-1.19 1.25-1.45 2.3.02-1.64.39-2.88 1.13-3.73C4.86 8.43 5.82 8 7.01 8V6l4 3-4 3H7z"></path></svg>
+          {% else %}
+            <svg height="16" viewBox="0 0 12 16" width="12"><path fill-rule="evenodd" d="M8.5 1H1c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h10c.55 0 1-.45 1-1V4.5L8.5 1zM11 14H1V2h7l3 3v9zM6 4.5l4 3-4 3v-2c-.98-.02-1.84.22-2.55.7-.71.48-1.19 1.25-1.45 2.3.02-1.64.39-2.88 1.13-3.73.73-.84 1.69-1.27 2.88-1.27v-2H6z"></path></svg>
           {% endif %}
           </div>
           <a href="{{ file.path }}">{{ file.name }}</a>

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -231,6 +231,8 @@ impl MyService {
             if res.status() != StatusCode::PartialContent {
                 body = handle_file(path);
             }
+            res.headers_mut().set(last_modified);
+            res.headers_mut().set(etag);
         }
 
         let mut body = body


### PR DESCRIPTION
To solve #22, users need symlink following feature must explicitly turn on `--follow-links` flag. The intent is to prevent unexpected exposing sensitive data to the network.
