### PR TITLE
Fix relatively hidden on `PathExt::is_hidden`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target/
+**/target
 **/*.rs.bk
 
 .vscode

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -126,14 +126,14 @@ mod t_extensions {
     use super::*;
     use std::path::PathBuf;
 
-    fn file_txt_path() -> std::path::PathBuf {
-        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fn file_txt_path() -> PathBuf {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("./tests/file.txt");
         path
     }
 
-    fn hidden_html_path() -> std::path::PathBuf {
-        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fn hidden_html_path() -> PathBuf {
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("./tests/.hidden.html");
         path
     }
@@ -178,7 +178,7 @@ mod t_extensions {
 
     #[test]
     fn path_type_() {
-        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
         let mut dir_path = path.clone();
         dir_path.push("./tests/dir");

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -396,6 +396,8 @@ mod t_server {
     }
 
     fn bootstrap(args: Args) -> (InnerService, Response) {
+        std::env::set_current_dir(env!("CARGO_MANIFEST_DIR"))
+            .expect("fail to set project root as current working directory");
         (InnerService::new(args), Response::default())
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -185,9 +185,9 @@ impl InnerService {
     /// A path is considered as hidden if matches all rules below:
     ///
     /// 1. `all` arg is false
-    /// 2. is hidden (prefixed with dot `.`)
+    /// 2. any component of the path is hidden (prefixed with dot `.`)
     fn path_is_hidden<P: AsRef<Path>>(&self, path: P) -> bool {
-        !self.args.all && path.as_ref().is_hidden()
+        !self.args.all && path.as_ref().is_relatively_hidden()
     }
 
     /// Determine if given path is ignored.


### PR DESCRIPTION
- `PathExt::is_hidden` renamed to `PathExt::is_relatively_hidden` and now would check if any parent path component is prefixed with a dot.
- Bootstrap of service tests now would set cargo manifest directory as current working directory.