### PR TITLE
Refactor/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The simplest way to start serving files is to run this command:
 sfz [FLAGS] [OPTIONS] [path]
 ```
 
-The command above will start serving your current working directory on `0.0.0.0:5000` by default.
+The command above will start serving your current working directory on `127.0.0.1:5000` by default.
 
 If you want to serve another directory, pass `[path]` positional argument in with either absolute or relaitve path.
 
@@ -117,7 +117,7 @@ FLAGS:
     -V, --version         Prints version information
 
 OPTIONS:
-    -b, --bind <address>        Specify bind address [default: 0.0.0.0]
+    -b, --bind <address>        Specify bind address [default: 127.0.0.1]
     -c, --cache <seconds>       Specify max-age of HTTP caching in seconds [default: 0]
         --path-prefix <path>    Specify an url path prefix, helpful when running behing a reverse proxy
     -p, --port <port>           Specify port to listen on [default: 5000]

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -22,7 +22,7 @@ pub fn app() -> App<'static, 'static> {
     let arg_address = Arg::with_name("address")
         .short("b")
         .long("bind")
-        .default_value("0.0.0.0")
+        .default_value("127.0.0.1")
         .help("Specify bind address")
         .value_name("address");
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -7,11 +7,11 @@
 // except according to those terms.
 
 use clap::{app_from_crate, crate_authors, crate_description, crate_name, crate_version};
-use clap::{App, Arg};
+use clap::{ArgMatches, Arg};
 
 const ABOUT: &str = concat!("\n", crate_description!()); // Add extra newline.
 
-pub fn app() -> App<'static, 'static> {
+pub fn matches<'a>() -> ArgMatches<'a> {
     let arg_port = Arg::with_name("port")
         .short("p")
         .long("port")
@@ -90,4 +90,16 @@ pub fn app() -> App<'static, 'static> {
         .arg(arg_follow_links)
         .arg(arg_render_index)
         .arg(arg_path_prefix)
+        .get_matches()
+}
+
+#[cfg(test)]
+mod t {
+    use super::*;
+
+    #[test]
+    fn get_matches() {
+        let matches = matches();
+        assert!(matches.usage().starts_with("USAGE"))
+    }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -9,13 +9,13 @@
 use std::env;
 use std::fs::canonicalize;
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{value_t, App};
 
 use crate::BoxResult;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Args {
     pub address: String,
     pub port: u16,
@@ -51,10 +51,7 @@ impl Args {
         let follow_links = matches.is_present("follow-links");
         let render_index = matches.is_present("render-index");
         let log = !matches.is_present("no-log");
-
-        let path_prefix = matches
-            .value_of("path-prefix")
-            .and_then(|p| Some(p.to_owned()));
+        let path_prefix = matches.value_of("path-prefix").map(str::to_string);
 
         Ok(Args {
             address,
@@ -73,25 +70,24 @@ impl Args {
     }
 
     /// Parse path.
-    fn parse_path(path: &str) -> BoxResult<PathBuf> {
-        let path = PathBuf::from(path);
+    fn parse_path<P: AsRef<Path>>(path: P) -> BoxResult<PathBuf> {
+        let path = path.as_ref();
         if !path.exists() {
             bail!("error: path \"{}\" doesn't exist", path.display());
         }
 
-        (if path.is_absolute() {
-            path.canonicalize()
-        } else {
-            env::current_dir().map(|p| p.join(&path))
-        })
-        .and_then(canonicalize)
-        .or_else(|err| {
-            bail!(
-                "error: failed to access path \"{}\": {}",
-                path.display(),
-                err,
-            )
-        })
+        env::current_dir()
+            .and_then(|mut p| {
+                p.push(path); // If path is absolute, it replaces the current path.
+                canonicalize(p)
+            })
+            .or_else(|err| {
+                bail!(
+                    "error: failed to access path \"{}\": {}",
+                    path.display(),
+                    err,
+                )
+            })
     }
 
     /// Construct socket address from arguments.
@@ -112,36 +108,73 @@ impl Args {
 #[cfg(test)]
 mod t {
     use super::*;
+    use crate::app;
     use std::fs::File;
     use tempdir::TempDir;
 
-    fn temp_name() -> &'static str {
+    const fn temp_name() -> &'static str {
         concat!(env!("CARGO_PKG_NAME"), "-", env!("CARGO_PKG_VERSION"))
+    }
+
+    #[test]
+    fn parse_default() {
+        let old_wd = env::current_dir().unwrap();
+
+        env::set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let args = Args::parse(app()).unwrap();
+        assert_eq!(
+            args,
+            Args {
+                address: "127.0.0.1".to_string(),
+                all: false,
+                cache: 0,
+                compress: true,
+                cors: false,
+                follow_links: false,
+                ignore: true,
+                log: true,
+                path: env!("CARGO_MANIFEST_DIR").into(),
+                path_prefix: None,
+                render_index: false,
+                port: 5000
+            }
+        );
+
+        // Restore old working directory
+        env::set_current_dir(old_wd).unwrap();
     }
 
     #[test]
     fn parse_absolute_path() {
         let tmp_dir = TempDir::new(temp_name()).unwrap();
         let path = tmp_dir.path().join("temp.txt");
-        let path_str = path.to_str().unwrap();
         assert!(path.is_absolute());
         // error: No exists
-        assert!(Args::parse_path(path_str).is_err());
+        assert!(Args::parse_path(&path).is_err());
         // create file
         File::create(&path).unwrap();
-        assert!(Args::parse_path(path_str).is_ok());
+        assert_eq!(
+            Args::parse_path(&path).unwrap(),
+            path.canonicalize().unwrap(),
+        );
     }
 
     #[test]
     fn parse_relative_path() {
+        let old_wd = env::current_dir().unwrap();
+
         let tmp_dir = TempDir::new(temp_name()).unwrap();
-        let path = tmp_dir.path().join("temp.txt");
-        let relative_path = path.strip_prefix(tmp_dir.path()).unwrap();
-        let relative_path_str = path.to_str().unwrap();
+        let relative_path: &Path = "temp.txt".as_ref();
         env::set_current_dir(tmp_dir.path()).unwrap();
-        File::create(&relative_path).unwrap();
+        File::create(relative_path).unwrap();
+
         assert!(relative_path.is_relative());
-        // Relative path is ok
-        assert!(Args::parse_path(relative_path_str).is_ok());
+        assert_eq!(
+            Args::parse_path(relative_path).unwrap(),
+            tmp_dir.path().join(relative_path).canonicalize().unwrap(),
+        );
+
+        // Restore old working directory
+        env::set_current_dir(old_wd).unwrap();
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -11,7 +11,7 @@ use std::fs::canonicalize;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use clap::{value_t, App};
+use clap::{value_t, ArgMatches};
 
 use crate::BoxResult;
 
@@ -36,8 +36,7 @@ impl Args {
     ///
     /// If a parsing error ocurred, exit the process and print out informative
     /// error message to user.
-    pub fn parse(app: App<'_, '_>) -> BoxResult<Args> {
-        let matches = app.get_matches();
+    pub fn parse(matches: ArgMatches<'_>) -> BoxResult<Args> {
         let address = matches.value_of("address").unwrap_or_default().to_owned();
         let port = value_t!(matches.value_of("port"), u16)?;
         let cache = value_t!(matches.value_of("cache"), u64)?;
@@ -108,7 +107,7 @@ impl Args {
 #[cfg(test)]
 mod t {
     use super::*;
-    use crate::app;
+    use crate::matches;
     use std::fs::File;
     use tempdir::TempDir;
 
@@ -121,7 +120,7 @@ mod t {
         let old_wd = env::current_dir().unwrap();
 
         env::set_current_dir(env!("CARGO_MANIFEST_DIR")).unwrap();
-        let args = Args::parse(app()).unwrap();
+        let args = Args::parse(matches()).unwrap();
         assert_eq!(
             args,
             Args {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,5 +9,5 @@
 mod app;
 mod args;
 
-pub use self::app::app;
+pub use self::app::matches;
 pub use self::args::Args;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,14 @@ mod extensions;
 mod http;
 mod server;
 
-use crate::cli::{app, Args};
+use crate::cli::{matches, Args};
 use crate::server::serve;
 
 pub type BoxResult<T> = Result<T, Box<dyn std::error::Error>>;
 
 #[tokio::main]
 async fn main() {
-    Args::parse(app())
+    Args::parse(matches())
         .map(serve)
         .unwrap_or_else(handle_err)
         .await


### PR DESCRIPTION
Breaking:

- default socket address from 0.0.0.0 to 127.0.0.1
- rename `cli::app` to `cli::matches` and return `clap::ArgMatches` instead of `clap::App`
- deduplicate args path parsing logic