### PR TITLE
fix: add prefix slash for path-prefix

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -50,7 +50,8 @@ impl Args {
         let follow_links = matches.is_present("follow-links");
         let render_index = matches.is_present("render-index");
         let log = !matches.is_present("no-log");
-        let path_prefix = matches.value_of("path-prefix").map(str::to_string);
+        let path_prefix = matches.value_of("path-prefix")
+            .map(|s| format!("/{}", s.trim_start_matches('/')));
 
         Ok(Args {
             address,

--- a/src/server/send.rs
+++ b/src/server/send.rs
@@ -247,14 +247,14 @@ mod t {
     fn prefixed_breadcrumbs() {
         let base_path = Path::new("/a");
         let dir_path = Path::new("/a/b/c");
-        let breadcrumbs = create_breadcrumbs(dir_path, base_path, "xdd~帥//");
+        let breadcrumbs = create_breadcrumbs(dir_path, base_path, "/xdd~帥//");
         assert_eq!(breadcrumbs.len(), 3);
         assert_eq!(breadcrumbs[0].name, "a");
-        assert_eq!(breadcrumbs[0].path, "xdd~帥///");
+        assert_eq!(breadcrumbs[0].path, "/xdd~帥///");
         assert_eq!(breadcrumbs[1].name, "b");
-        assert_eq!(breadcrumbs[1].path, "xdd~帥///b");
+        assert_eq!(breadcrumbs[1].path, "/xdd~帥///b");
         assert_eq!(breadcrumbs[2].name, "c");
-        assert_eq!(breadcrumbs[2].path, "xdd~帥///b/c");
+        assert_eq!(breadcrumbs[2].path, "/xdd~帥///b/c");
     }
 
     #[test]


### PR DESCRIPTION
It seems that the bug was introduced along with the path-prefix feature. Now all files link/path render in html would get their prefix slash. That is to say, if you add path-prefix`my-prefix` and request for README.md, the link was rendered as `my-prefix/README.md` before now gets a correct `/my-prefix/README.md`.