### PR TITLE
Windows paths

### DIFF
--- a/src/server/send.rs
+++ b/src/server/send.rs
@@ -87,11 +87,15 @@ pub fn send_dir<P1: AsRef<Path>, P2: AsRef<Path>>(
             Item {
                 path_type: abs_path.type_(),
                 name: rel_path.filename_str().to_owned(),
-                path: format!("{}/{}", prefix, if cfg!(windows){
-                    rel_path_ref.replace("\\", "/")
-                } else {
-                    rel_path_ref.to_string()
-                }),
+                path: format!(
+                    "{}/{}",
+                    prefix,
+                    if cfg!(windows) {
+                        rel_path_ref.replace("\\", "/")
+                    } else {
+                        rel_path_ref.to_string()
+                    }
+                ),
             }
         });
 

--- a/src/server/send.rs
+++ b/src/server/send.rs
@@ -87,7 +87,11 @@ pub fn send_dir<P1: AsRef<Path>, P2: AsRef<Path>>(
             Item {
                 path_type: abs_path.type_(),
                 name: rel_path.filename_str().to_owned(),
-                path: format!("{}/{}", prefix, rel_path_ref),
+                path: format!("{}/{}", prefix, if cfg!(windows){
+                    rel_path_ref.replace("\\", "/")
+                } else {
+                    rel_path_ref.to_string()
+                }),
             }
         });
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -120,12 +120,11 @@ impl InnerService {
     /// 5. Concatenate base path and requested path.
     fn file_path_from_path(&self, path: &str) -> Result<Option<PathBuf>, Utf8Error> {
         let decoded = percent_decode(path[1..].as_bytes())
-            .decode_utf8()?
-            .into_owned();
+            .decode_utf8()?;
         let slashes_switched = if cfg!(windows) {
             decoded.replace("/", "\\")
         } else {
-            decoded
+            decoded.into_owned()
         };
         let stripped_path = match self.strip_path_prefix(&slashes_switched) {
             Some(path) => path,

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -122,7 +122,7 @@ impl InnerService {
         let decoded = percent_decode(path[1..].as_bytes())
             .decode_utf8()?
             .into_owned();
-        let slashes_switched = if cfg!(windows){
+        let slashes_switched = if cfg!(windows) {
             decoded.replace("/", "\\")
         } else {
             decoded

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -119,8 +119,7 @@ impl InnerService {
     /// 4. If on windows, switch slashes
     /// 5. Concatenate base path and requested path.
     fn file_path_from_path(&self, path: &str) -> Result<Option<PathBuf>, Utf8Error> {
-        let decoded = percent_decode(path[1..].as_bytes())
-            .decode_utf8()?;
+        let decoded = percent_decode(path[1..].as_bytes()).decode_utf8()?;
         let slashes_switched = if cfg!(windows) {
             decoded.replace("/", "\\")
         } else {


### PR DESCRIPTION
Currently sfz does not properly switch between the forward slashes used in urls and unix file paths to the backslashes used in windows paths, instead percent encoding them, which is a bit ugly and cumbersome to work with.  So I added some logic to check the OS and if its windows switch the slashes where appropriate.

(Note: it fails two tests on windows, _but_ it also was failing those before I made any changes