### PR TITLE
fix: do not use stdin which will stop when running in background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,15 +325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "http"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,16 +517,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -953,7 +934,6 @@ dependencies = [
  "autocfg",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "tokio-macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2018"
 # Command-line
 clap = { version = "2.33", default-features = false }
 # Server
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1", features = ["rt", "macros"]}
 hyper = { version = "0.14.4", features = ["http1", "server", "tcp"] }
 headers = "0.3"
 mime_guess = "2.0"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ sfz /usr/local
 # Serve files under `/usr/local` directory.
 # 
 # You can press ctrl-c to exit immediately.
-# For shutting down the server gracefully, press Ctrl-d.
 ```
 
 ### Flags and Options

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 use std::convert::{AsRef, Infallible};
-use std::future::Future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::Utf8Error;
@@ -53,7 +52,7 @@ pub enum PathType {
 }
 
 /// Run the server.
-pub async fn serve(args: Args, f: impl Future<Output = ()>) -> BoxResult<()> {
+pub async fn serve(args: Args) -> BoxResult<()> {
     let address = args.address()?;
     let path_prefix = args.path_prefix.clone().unwrap_or_default();
     let inner = Arc::new(InnerService::new(args));
@@ -69,11 +68,8 @@ pub async fn serve(args: Args, f: impl Future<Output = ()>) -> BoxResult<()> {
 
     let server = hyper::Server::try_bind(&address)?.serve(make_svc);
     let address = server.local_addr();
-    eprintln!(
-        "Files served on http://{}{}\nPress Ctrl-D to exit gracefully.",
-        address, path_prefix
-    );
-    server.with_graceful_shutdown(f).await?;
+    eprintln!("Files served on http://{}{}", address, path_prefix);
+    server.await?;
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #65.

This bug was introduced by #63, which is too rush to handle STDIN inproperly. Although we can try to handle STGTTIN in Unix system but I cannot find an easy way to deal other platform like Windows. We'll revert the Ctrl-D key binding feature and back to the good old Ctrl-C.

> When a process in a background job tries to read from its controlling terminal, the process group is usually sent a SIGTTIN signal. This normally causes all of the processes in that group to stop (unless they handle the signal and don’t stop themselves). 

Ref: https://www.gnu.org/software/libc/manual/html_node/Access-to-the-Terminal.html