### PR TITLE
Remove trailing semicolon in bail macro

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@
 
 macro_rules! bail {
     ($($tt:tt)*) => {
-        return Err(From::from(format!($($tt)*)));
+        return Err(From::from(format!($($tt)*)))
     }
 }
 


### PR DESCRIPTION
Trailing semicolon in bail macro leads to a compiler warning:
```
warning: trailing semicolon in macro used in expression position
  --> src\main.rs:11:49
   |
11 |           return Err(From::from(format!($($tt)*)));
   |                                                   ^
   |
  ::: src\cli\args.rs:86:17
   |
86 | /                 bail!(
87 | |                     "error: failed to access path \"{}\": {}",
88 | |                     path.display(),
89 | |                     err,
90 | |                 )
   | |_________________- in this macro invocation
   |
   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
   = note: macro invocations at the end of a block are treated as expressions
   = note: to ignore the value produced by the macro, add a semicolon after the invocation of `bail`
   = note: this warning originates in the macro `bail` (in Nightly builds, run with -Z macro-backtrace for more info)
```
By removing it, we will make the world a little better