### PR TITLE
chore: bump to clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,13 +171,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
  "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "textwrap",
- "unicode-width",
 ]
 
 [[package]]
@@ -344,6 +346,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "headers"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +455,16 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -581,6 +599,15 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "parse-zoneinfo"
@@ -966,12 +993,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -1148,12 +1172,6 @@ checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
  "version_check",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 
 [dependencies]
 # Command-line
-clap = { version = "2.33", default-features = false }
+clap = { version = "3", default-features = false, features = ["std", "cargo"] }
 # Server
 tokio = { version = "1", features = ["rt", "macros"]}
 hyper = { version = "0.14.10", features = ["http1", "server", "tcp"] }

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -6,72 +6,73 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::{app_from_crate, crate_authors, crate_description, crate_name, crate_version};
+use clap::{app_from_crate, crate_description};
 use clap::{Arg, ArgMatches};
 
 const ABOUT: &str = concat!("\n", crate_description!()); // Add extra newline.
 
-pub fn matches<'a>() -> ArgMatches<'a> {
-    let arg_port = Arg::with_name("port")
-        .short("p")
+fn app() -> clap::App<'static> {
+    let arg_port = Arg::new("port")
+        .short('p')
         .long("port")
         .default_value("5000")
         .help("Specify port to listen on")
         .value_name("port");
 
-    let arg_address = Arg::with_name("address")
-        .short("b")
+    let arg_address = Arg::new("address")
+        .short('b')
         .long("bind")
         .default_value("127.0.0.1")
         .help("Specify bind address")
         .value_name("address");
 
-    let arg_cors = Arg::with_name("cors")
-        .short("C")
+    let arg_cors = Arg::new("cors")
+        .short('C')
         .long("cors")
         .help("Enable Cross-Origin Resource Sharing from any origin (*)");
 
-    let arg_cache = Arg::with_name("cache")
-        .short("c")
+    let arg_cache = Arg::new("cache")
+        .short('c')
         .long("cache")
         .default_value("0")
         .help("Specify max-age of HTTP caching in seconds")
         .value_name("seconds");
 
-    let arg_path = Arg::with_name("path")
+    let arg_path = Arg::new("path")
         .default_value(".")
+        .allow_invalid_utf8(true)
         .help("Path to a directory for serving files");
 
-    let arg_unzipped = Arg::with_name("unzipped")
-        .short("Z")
+    let arg_unzipped = Arg::new("unzipped")
+        .short('Z')
         .long("unzipped")
         .help("Disable HTTP compression");
 
-    let arg_all = Arg::with_name("all")
-        .short("a")
+    let arg_all = Arg::new("all")
+        .short('a')
         .long("all")
         .help("Serve hidden and dot (.) files");
 
-    let arg_no_ignore = Arg::with_name("no-ignore")
-        .short("I")
+    let arg_no_ignore = Arg::new("no-ignore")
+        .short('I')
         .long("no-ignore")
         .help("Don't respect gitignore file");
 
-    let arg_no_log = Arg::with_name("no-log")
+    let arg_no_log = Arg::new("no-log")
         .long("--no-log")
         .help("Don't log any request/response information.");
 
-    let arg_follow_links = Arg::with_name("follow-links")
-        .short("L")
+    let arg_follow_links = Arg::new("follow-links")
+        .short('L')
         .long("--follow-links")
         .help("Follow symlinks outside current serving base path");
 
-    let arg_render_index = Arg::with_name("render-index")
-        .short("r")
+    let arg_render_index = Arg::new("render-index")
+        .short('r')
         .long("--render-index")
         .help("Render existing index.html when requesting a directory.");
 
-    let arg_path_prefix = Arg::with_name("path-prefix")
+    let arg_path_prefix = Arg::new("path-prefix")
         .long("path-prefix")
         .help("Specify an url path prefix, helpful when running behing a reverse proxy")
         .value_name("path");
@@ -90,7 +91,10 @@ pub fn matches<'a>() -> ArgMatches<'a> {
         .arg(arg_follow_links)
         .arg(arg_render_index)
         .arg(arg_path_prefix)
-        .get_matches()
+}
+
+pub fn matches() -> ArgMatches {
+    app().get_matches()
 }
 
 #[cfg(test)]
@@ -98,8 +102,7 @@ mod t {
     use super::*;
 
     #[test]
-    fn get_matches() {
-        let matches = matches();
-        assert!(matches.usage().starts_with("USAGE"))
+    fn verify_app() {
+        app().debug_assert();
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -11,7 +11,7 @@ use std::fs::canonicalize;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
-use clap::{value_t, ArgMatches};
+use clap::ArgMatches;
 
 use crate::BoxResult;
 
@@ -36,12 +36,12 @@ impl Args {
     ///
     /// If a parsing error ocurred, exit the process and print out informative
     /// error message to user.
-    pub fn parse(matches: ArgMatches<'_>) -> BoxResult<Args> {
+    pub fn parse(matches: ArgMatches) -> BoxResult<Args> {
         let address = matches.value_of("address").unwrap_or_default().to_owned();
-        let port = value_t!(matches.value_of("port"), u16)?;
-        let cache = value_t!(matches.value_of("cache"), u64)?;
+        let port = matches.value_of_t::<u16>("port")?;
+        let cache = matches.value_of_t::<u64>("cache")?;
         let cors = matches.is_present("cors");
-        let path = matches.value_of("path").unwrap_or_default();
+        let path = matches.value_of_os("path").unwrap_or_default();
         let path = Args::parse_path(path)?;
 
         let compress = !matches.is_present("unzipped");


### PR DESCRIPTION
- Update deprecate methods
- allow invalid utf8 on path related args
  (disallow by default since v3)