### PR TITLE
feat: add arg `coi` for cross-origin isolation

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -31,6 +31,10 @@ fn app() -> clap::App<'static> {
         .long("cors")
         .help("Enable Cross-Origin Resource Sharing from any origin (*)");
 
+    let arg_coi = Arg::new("coi")
+        .long("coi")
+        .help("Enable Cross-Origin isolation");
+
     let arg_cache = Arg::new("cache")
         .short('c')
         .long("cache")
@@ -83,6 +87,7 @@ fn app() -> clap::App<'static> {
         .arg(arg_port)
         .arg(arg_cache)
         .arg(arg_cors)
+        .arg(arg_coi)
         .arg(arg_path)
         .arg(arg_unzipped)
         .arg(arg_all)

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -21,6 +21,7 @@ pub struct Args {
     pub port: u16,
     pub cache: u64,
     pub cors: bool,
+    pub coi: bool,
     pub compress: bool,
     pub path: PathBuf,
     pub all: bool,
@@ -41,6 +42,7 @@ impl Args {
         let port = matches.value_of_t::<u16>("port")?;
         let cache = matches.value_of_t::<u64>("cache")?;
         let cors = matches.is_present("cors");
+        let coi = matches.is_present("coi");
         let path = matches.value_of_os("path").unwrap_or_default();
         let path = Args::parse_path(path)?;
 
@@ -59,6 +61,7 @@ impl Args {
             port,
             cache,
             cors,
+            coi,
             path,
             compress,
             all,
@@ -122,6 +125,7 @@ mod t {
                 port: 5000,
                 cache: 0,
                 cors: true,
+                coi: true,
                 compress: true,
                 path: ".".into(),
                 all: true,
@@ -159,6 +163,7 @@ mod t {
                     cache: 0,
                     compress: true,
                     cors: false,
+                    coi: false,
                     follow_links: false,
                     ignore: true,
                     log: true,


### PR DESCRIPTION
Resolves #83 

Follow this site and implement COOP and COEP headers https://web.dev/coop-coep/

```console
$ cargo run -- --coi
```

Open the site and check the headers:

<img width="225" alt="image" src="https://user-images.githubusercontent.com/14314532/150365867-0f79843a-09aa-4bbe-80f9-f05888c678cc.png">
