### PR TITLE
Support user-defined style

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ OPTIONS:
         --path-prefix <path>    Specify an url path prefix, helpful when running behing a reverse
                                 proxy
     -r, --render-index          Render existing index.html when requesting a directory.
+        --style <style>         Specify a user-defined style to override the default one [default: ]
     -V, --version               Print version information
     -Z, --unzipped              Disable HTTP compression
 ```

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -81,6 +81,12 @@ fn app() -> clap::Command<'static> {
         .help("Specify an url path prefix, helpful when running behing a reverse proxy")
         .value_name("path");
 
+    let arg_user_style = Arg::new("user_style")
+        .long("style")
+        .default_value("")
+        .help("Specify a user-defined style to override the default one")
+        .value_name("style");
+
     clap::command!()
         .about(ABOUT)
         .arg(arg_address)
@@ -96,6 +102,7 @@ fn app() -> clap::Command<'static> {
         .arg(arg_follow_links)
         .arg(arg_render_index)
         .arg(arg_path_prefix)
+        .arg(arg_user_style)
 }
 
 pub fn matches() -> ArgMatches {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -56,7 +56,10 @@ impl Args {
         let path_prefix = matches
             .value_of("path-prefix")
             .map(|s| format!("/{}", s.trim_start_matches('/')));
-        let user_style = matches.value_of("user_style").unwrap_or_default().to_string();
+        let user_style = matches
+            .value_of("user_style")
+            .unwrap_or_default()
+            .to_string();
 
         Ok(Args {
             address,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -30,6 +30,7 @@ pub struct Args {
     pub render_index: bool,
     pub log: bool,
     pub path_prefix: Option<String>,
+    pub user_style: String,
 }
 
 impl Args {
@@ -55,6 +56,7 @@ impl Args {
         let path_prefix = matches
             .value_of("path-prefix")
             .map(|s| format!("/{}", s.trim_start_matches('/')));
+        let user_style = matches.value_of("user_style").unwrap_or_default().to_string();
 
         Ok(Args {
             address,
@@ -70,6 +72,7 @@ impl Args {
             render_index,
             log,
             path_prefix,
+            user_style,
         })
     }
 
@@ -134,6 +137,7 @@ mod t {
                 render_index: true,
                 log: true,
                 path_prefix: None,
+                user_style: "".to_owned(),
             }
         }
     }
@@ -170,7 +174,8 @@ mod t {
                     path,
                     path_prefix: None,
                     render_index: false,
-                    port: 5000
+                    port: 5000,
+                    user_style: "".to_string(),
                 }
             );
         });

--- a/src/server/index.html
+++ b/src/server/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width" />
     <title>Files in {{ dir_name }}/</title>
     <style>{{ style | safe }}</style>
+    <style>{{ user_style | safe }}</style>
   </head>
   <body>
     <div class="breadcrumbs">

--- a/src/server/send.rs
+++ b/src/server/send.rs
@@ -342,6 +342,12 @@ mod t {
         assert_eq!(breadcrumbs[2].name, "b");
         assert_eq!(breadcrumbs[2].path, "/a/b");
     }
+
+    #[test]
+    fn render_user_defined_style() {
+        let page = render("", &vec![], &vec![], "li { width: 400px; }");
+        assert!(page.contains("<style>li { width: 400px; }</style>"))
+    }
 }
 
 #[cfg(test)]

--- a/src/server/send.rs
+++ b/src/server/send.rs
@@ -65,6 +65,7 @@ pub fn send_dir<P1: AsRef<Path>, P2: AsRef<Path>>(
     show_all: bool,
     with_ignore: bool,
     path_prefix: Option<&str>,
+    user_style: &str,
 ) -> io::Result<Vec<u8>> {
     let base_path = base_path.as_ref();
     let dir_path = dir_path.as_ref();
@@ -130,7 +131,7 @@ pub fn send_dir<P1: AsRef<Path>, P2: AsRef<Path>>(
     // Sort files (dir-first and lexicographic ordering).
     files.sort_unstable();
 
-    Ok(render(dir_path.filename_str(), &files, &breadcrumbs).into())
+    Ok(render(dir_path.filename_str(), &files, &breadcrumbs, user_style).into())
 }
 
 /// Send a buffer of file to client.
@@ -247,12 +248,13 @@ fn create_breadcrumbs<'a>(
 }
 
 /// Render page with Tera template engine.
-fn render(dir_name: &str, files: &[Item], breadcrumbs: &[Breadcrumb]) -> String {
+fn render(dir_name: &str, files: &[Item], breadcrumbs: &[Breadcrumb], user_style: &str) -> String {
     let mut ctx = Context::new();
     ctx.insert("dir_name", dir_name);
     ctx.insert("files", files);
     ctx.insert("breadcrumbs", breadcrumbs);
     ctx.insert("style", include_str!("style.css"));
+    ctx.insert("user_style", user_style);
     Tera::one_off(include_str!("index.html"), &ctx, true)
         .unwrap_or_else(|e| format!("500 Internal server error: {}", e))
 }
@@ -263,7 +265,7 @@ mod t {
 
     #[test]
     fn render_successfully() {
-        let page = render("", &vec![], &vec![]);
+        let page = render("", &vec![], &vec![], "");
         assert!(page.starts_with("<!DOCTYPE html>"))
     }
     #[test]

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -324,6 +324,7 @@ impl InnerService {
                     self.args.all,
                     self.args.ignore,
                     self.args.path_prefix.as_deref(),
+                    &self.args.user_style,
                 );
             }
             Action::DownloadFile => {


### PR DESCRIPTION
Add a `--style <style>` option to the command line so that user-defined css will work for file listing pages.

For example, use the following.

```bash
$ sfz -p 4000 --style 'li { width: 400px; }'
```

This feature is related to #89.