### PR TITLE
Fix severe compression bug introduced by #97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +946,7 @@ dependencies = [
 name = "sfz"
 version = "0.7.1"
 dependencies = [
+ "async-compression",
  "brotli",
  "bytes",
  "chrono",
@@ -949,6 +964,7 @@ dependencies = [
  "tempfile",
  "tera",
  "tokio",
+ "tokio-util",
  "zip",
 ]
 
@@ -1127,6 +1143,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,11 +947,9 @@ name = "sfz"
 version = "0.7.1"
 dependencies = [
  "async-compression",
- "brotli",
  "bytes",
  "chrono",
  "clap",
- "flate2",
  "futures",
  "headers",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,12 @@ headers = "0.3"
 mime_guess = "2.0"
 percent-encoding = "2.1"
 # Compression
-brotli = "3"
-flate2 = "1"
+async-compression = { version = "0.3.7", features = [
+  "brotli",
+  "deflate",
+  "gzip",
+  "tokio",
+] }
 # Rendering
 tera = "1"
 serde = { version = "1.0", features = [
@@ -40,12 +44,6 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 futures = "0.3"
 tempfile = "3"
 bytes = "1"
-async-compression = { version = "0.3.7", features = [
-  "brotli",
-  "deflate",
-  "gzip",
-  "tokio",
-] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2021"
 clap = { version = "3", default-features = false, features = ["std", "cargo"] }
 # Server
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio-util = { version = "0.7", features = ["io"] }
 hyper = { version = "0.14.20", features = ["http1", "server", "tcp", "stream"] }
 headers = "0.3"
 mime_guess = "2.0"
@@ -39,6 +40,12 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 futures = "0.3"
 tempfile = "3"
 bytes = "1"
+async-compression = { version = "0.3.7", features = [
+  "brotli",
+  "deflate",
+  "gzip",
+  "tokio",
+] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/http/content_encoding.rs
+++ b/src/http/content_encoding.rs
@@ -259,7 +259,7 @@ mod t_compress {
     async fn compressed() {
         let s = futures::stream::iter(vec![Ok::<_, io::Error>(Bytes::from_static(b"xxxxx"))]);
         let body = compress_stream(s, BR).unwrap();
-        assert_eq!(hyper::body::to_bytes(body).await.unwrap().len(), 10);
+        assert_eq!(hyper::body::to_bytes(body).await.unwrap().len(), 9);
 
         let s = futures::stream::iter(vec![Ok::<_, io::Error>(Bytes::from_static(b"xxxxx"))]);
         let body = compress_stream(s, DEFLATE).unwrap();

--- a/src/http/content_encoding.rs
+++ b/src/http/content_encoding.rs
@@ -132,7 +132,7 @@ pub fn get_prior_encoding<'a>(accept_encoding: &'a HeaderValue) -> &'static str 
 ///
 /// # Parameters
 ///
-/// * `input` - [`futures::stream::Stream`](futures::stream::Stream) to be compressed e.g. [`hyper::body::Body`](hyper::body::Body).
+/// * `input` - [`futures::stream::Stream`] to be compressed, e.g. [`hyper::body::Body`].
 /// * `encoding` - Only support `br`, `deflate`, `gzip` and `identity`.
 pub fn compress_stream(
     input: impl Stream<Item = io::Result<Bytes>> + Send + 'static,

--- a/src/http/content_encoding.rs
+++ b/src/http/content_encoding.rs
@@ -129,7 +129,7 @@ pub fn get_prior_encoding<'a>(accept_encoding: &'a HeaderValue) -> &'static str 
 }
 
 pub fn compress_stream(
-    input: impl Stream<Item = io::Result<Bytes>> + std::marker::Send + 'static,
+    input: impl Stream<Item = io::Result<Bytes>> + Send + 'static,
     encoding: &str,
 ) -> io::Result<hyper::Body> {
     match encoding {
@@ -246,7 +246,6 @@ mod t_prior {
 #[cfg(test)]
 mod t_compress {
     use super::*;
-    use bytes::Bytes;
 
     #[test]
     fn failed() {

--- a/src/http/content_encoding.rs
+++ b/src/http/content_encoding.rs
@@ -9,7 +9,10 @@
 use std::cmp::Ordering;
 use std::io;
 
-use async_compression::tokio::bufread::{BrotliEncoder, DeflateEncoder, GzipEncoder};
+use async_compression::{
+    tokio::bufread::{BrotliEncoder, DeflateEncoder, GzipEncoder},
+    Level,
+};
 use bytes::Bytes;
 use futures::Stream;
 use hyper::header::HeaderValue;
@@ -130,9 +133,9 @@ pub fn compress_stream(
     encoding: &str,
 ) -> io::Result<hyper::Body> {
     match encoding {
-        BR => Ok(Body::wrap_stream(ReaderStream::new(BrotliEncoder::new(
-            StreamReader::new(input),
-        )))),
+        BR => Ok(Body::wrap_stream(ReaderStream::new(
+            BrotliEncoder::with_quality(StreamReader::new(input), Level::Fastest),
+        ))),
         DEFLATE => Ok(Body::wrap_stream(ReaderStream::new(DeflateEncoder::new(
             StreamReader::new(input),
         )))),

--- a/src/http/content_encoding.rs
+++ b/src/http/content_encoding.rs
@@ -128,6 +128,12 @@ pub fn get_prior_encoding<'a>(accept_encoding: &'a HeaderValue) -> &'static str 
         .unwrap_or(IDENTITY)
 }
 
+/// Compress data stream.
+///
+/// # Parameters
+///
+/// * `input` - [`futures::stream::Stream`](futures::stream::Stream) to be compressed e.g. [`hyper::body::Body`](hyper::body::Body).
+/// * `encoding` - Only support `br`, `deflate`, `gzip` and `identity`.
 pub fn compress_stream(
     input: impl Stream<Item = io::Result<Bytes>> + Send + 'static,
     encoding: &str,

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::Local;
-use futures::{StreamExt as _, TryStreamExt as _};
+use futures::TryStreamExt as _;
 use headers::{
     AcceptRanges, AccessControlAllowHeaders, AccessControlAllowOrigin, CacheControl, ContentLength,
     ContentType, ETag, HeaderMapExt, LastModified, Range, Server,
@@ -32,7 +32,7 @@ use serde::Serialize;
 use crate::cli::Args;
 use crate::extensions::{MimeExt, PathExt, SystemTimeExt};
 use crate::http::conditional_requests::{is_fresh, is_precondition_failed};
-use crate::http::content_encoding::{compress, get_prior_encoding, should_compress};
+use crate::http::content_encoding::{compress_stream, get_prior_encoding, should_compress};
 use crate::http::range_requests::{is_range_fresh, is_satisfiable_range};
 
 use crate::server::send::{send_dir, send_dir_as_zip, send_file, send_file_with_range};
@@ -411,13 +411,10 @@ impl InnerService {
             if let Some(encoding) = req.headers().get(hyper::header::ACCEPT_ENCODING) {
                 let content_encoding = get_prior_encoding(encoding);
                 if should_compress(content_encoding) {
-                    let stream = body
-                        .map_err(|_e| io::Error::from(io::ErrorKind::InvalidData))
-                        .map(|b| match b {
-                            Ok(b) => compress(&b, content_encoding),
-                            Err(e) => Err(e),
-                        });
-                    let body = Body::wrap_stream(stream);
+                    let b = compress_stream(
+                        body.map_err(|e| io::Error::new(io::ErrorKind::Other, e)),
+                        content_encoding,
+                    )?;
                     res.headers_mut().insert(
                         hyper::header::CONTENT_ENCODING,
                         hyper::header::HeaderValue::from_static(content_encoding),
@@ -427,7 +424,7 @@ impl InnerService {
                         hyper::header::VARY,
                         hyper::header::HeaderValue::from_name(hyper::header::ACCEPT_ENCODING),
                     );
-                    body
+                    b
                 } else {
                     body
                 }


### PR DESCRIPTION
closes #98 

# How to reproduce

- Prepare a large file, e.g. [Frankenstein; Or, The Modern Prometheus by Mary Wollstonecraft Shelley](https://www.gutenberg.org/ebooks/84), whose size should be greater than 4KB. Save it as `x.txt`.
- Check out master 70b431a.
- `cargo run`
- `curl --compressed http://localhost:5000/x.txt`

A error like `curl: (23) Failed reading the chunked-encoded stream` will occur and only first 4KB content of file will be returned.

# Root cause

https://github.com/weihanglo/sfz/blob/70b431ac3c272b2d0e060c34eb9593577bc14703/src/server/serve.rs#L416-L419

Maybe the body stream isn't split like how I expected, so only the first item of stream get compressed and returned then the rest are dropped. Since the buffer of file stream is 4KB, it might explain why only the first 4KB will be returned:

https://github.com/weihanglo/sfz/blob/70b431ac3c272b2d0e060c34eb9593577bc14703/src/server/send.rs#L160

# Solution

- I replace `compress` with `async-compression`.
- Compared to https://github.com/weihanglo/sfz/pull/97#issuecomment-1245448766 , there is no significant performance improvement or loss when client enables deflate or gzip.
- When it comes to brotli, compression level and response time are highly relevant, so this pull request also resolves #98 .

| brotli        | level = 6                                                                                                                                                                                                                                                                                                                                                    | level = 0, fastest                                                                                                                                                                                                                                                                                                                                           |
|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| benchmark     | Running 10s test @ http://localhost:5000/Cargo.toml<br>  2 threads and 10 connections<br>  Thread Stats   Avg      Stdev     Max   +/- Stdev<br>    Latency     5.45ms    2.20ms  23.10ms   72.66%<br>    Req/Sec     0.93k    79.59     1.06k    70.00%<br>  18434 requests in 10.01s, 18.09MB read<br>Requests/sec:   1841.70<br>Transfer/sec:      1.81MB | Running 10s test @ http://localhost:5000/Cargo.toml<br>  2 threads and 10 connections<br>  Thread Stats   Avg      Stdev     Max   +/- Stdev<br>    Latency     2.97ms    1.09ms  19.27ms   69.77%<br>    Req/Sec     1.70k   110.24     3.07k    96.52%<br>  33932 requests in 10.10s, 38.96MB read<br>Requests/sec:   3359.58<br>Transfer/sec:      3.86MB |
| response size (1561) | 700 (44%)                                                                                                                                                                                                                                                                                                                                                    | 875 (56%)                                                                                                                                                                                                                                                                                                                                                    |

- Another example: [Pride and Prejudice by Jane Austen](https://www.gutenberg.org/ebooks/1342)

| brotli        | level = 6                                                                                                                                                                                                                                                                                                                                                                                                           | level = 0, fastest                                                                                                                                                                                                                                                                                                                                             |
|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| benchmark     | Running 10s test @ http://localhost:5000/1342-0.txt<br>  2 threads and 10 connections<br>  Thread Stats   Avg      Stdev     Max   +/- Stdev<br>    Latency     1.30s   432.24ms   1.79s    76.92%<br>    Req/Sec     4.71      3.89    20.00     78.57%<br>  68 requests in 10.01s, 16.04MB read<br>  Socket errors: connect 0, read 0, write 0, timeout 3<br>Requests/sec:      6.79<br>Transfer/sec:      1.60MB | Running 10s test @ http://localhost:5000/1342-0.txt<br>  2 threads and 10 connections<br>  Thread Stats   Avg      Stdev     Max   +/- Stdev<br>    Latency   880.53ms  337.25ms   1.51s    68.52%<br>    Req/Sec     6.25      4.69    30.00     89.47%<br>  108 requests in 10.01s, 42.28MB read<br>Requests/sec:     **10.78**<br>Transfer/sec:      4.22MB |
| response size (798774) | 246517 (30%)                                                                                                                                                                                                                                                                                                                                                                                                        | 405123 (50%)                                                                                                                                                                                                                                                                                                                                                   |