### PR TITLE
Proper logging

### DIFF
--- a/src/http/loggable.rs
+++ b/src/http/loggable.rs
@@ -73,20 +73,11 @@ impl<B> LoggableBody<B>
 where
     B: HttpBody,
 {
-    pub fn new(log: Option<Log>, inner: B) -> Self {
+    pub fn new(log: Option<Log>, inner: B, content_length: Option<u64>) -> Self {
         Self {
             inner,
             bytes_sent: Default::default(),
-            content_length: None,
-            log,
-        }
-    }
-
-    pub fn with_content_length(log: Option<Log>, inner: B, content_length: u64) -> Self {
-        Self {
-            inner,
-            bytes_sent: Default::default(),
-            content_length: Some(content_length),
+            content_length,
             log,
         }
     }

--- a/src/http/loggable.rs
+++ b/src/http/loggable.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2018 Weihang Lo
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::atomic::{AtomicUsize, Ordering},
+    task::{Context, Poll},
+};
+
+use chrono::Local;
+use futures::ready;
+use hyper::{body::HttpBody, Method, Uri, Version};
+
+use crate::server::{Request, Response};
+
+#[derive(Default)]
+pub struct Log {
+    pub remote_addr: Option<IpAddr>,
+    pub method: Method,
+    pub uri: Uri,
+    pub status: u16,
+    pub version: Version,
+    pub user_agent: String,
+}
+
+impl Log {
+    pub fn new(remote_addr: SocketAddr, req: &Request, res: &Response) -> Self {
+        let user_agent = req
+            .headers()
+            .get(hyper::header::USER_AGENT)
+            .map(|s| s.to_str().ok().unwrap_or_default())
+            .unwrap_or("-");
+        Self {
+            remote_addr: Some(remote_addr.ip()),
+            method: req.method().clone(),
+            uri: req.uri().clone(),
+            status: res.status().as_u16(),
+            version: req.version(),
+            user_agent: user_agent.to_string(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct LoggableBody<B> {
+    pub inner: B,
+    pub bytes_sent: AtomicUsize,
+    pub content_length: Option<u64>,
+    pub log: Option<Log>,
+}
+
+impl<'a, B> From<&'a str> for LoggableBody<B>
+where
+    B: HttpBody + From<&'a str>,
+{
+    fn from(s: &'a str) -> Self {
+        Self {
+            inner: s.into(),
+            bytes_sent: Default::default(),
+            content_length: None,
+            log: None,
+        }
+    }
+}
+
+impl<B> LoggableBody<B>
+where
+    B: HttpBody,
+{
+    pub fn new(log: Option<Log>, inner: B) -> Self {
+        Self {
+            inner,
+            bytes_sent: Default::default(),
+            content_length: None,
+            log,
+        }
+    }
+
+    pub fn with_content_length(log: Option<Log>, inner: B, content_length: u64) -> Self {
+        Self {
+            inner,
+            bytes_sent: Default::default(),
+            content_length: Some(content_length),
+            log,
+        }
+    }
+}
+
+impl<B> HttpBody for LoggableBody<B>
+where
+    B: HttpBody + Unpin,
+    B::Data: std::fmt::Debug + bytes::Buf,
+{
+    type Data = B::Data;
+
+    type Error = B::Error;
+
+    fn poll_data(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        use bytes::Buf as _;
+
+        let polled = ready!(Pin::new(&mut self.inner).poll_data(cx));
+        if let Some(Ok(ref b)) = polled {
+            self.bytes_sent.fetch_add(b.remaining(), Ordering::AcqRel);
+        }
+
+        let done = if polled.is_none() {
+            true
+        } else if let Some(l) = self.content_length {
+            // If Content-Length header is set when body is not compressed,
+            // hyper will not call poll_data to get None,
+            // thus we cannot track when we should print the log message.
+            // We need to track whether the entire body was sent.
+            self.bytes_sent.load(Ordering::Acquire) == l as usize
+        } else {
+            false
+        };
+
+        if done {
+            if let Some(ref l) = self.log {
+                let ip = match l.remote_addr {
+                    None => "-".to_string(),
+                    Some(ip) => ip.to_string(),
+                };
+                let local_time = Local::now().format("%d/%b/%Y %H:%M:%S %z");
+                let method = &l.method;
+                let uri = &l.uri;
+                let version = l.version;
+                let status = l.status;
+                let bytes_sent = self.bytes_sent.load(Ordering::Acquire);
+                let user_agent = &l.user_agent;
+                println!(
+                    r#"{ip} - - [{local_time}] "{method} {uri} {version:?}" {status} {bytes_sent} "-" "{user_agent}" "-""#
+                );
+            }
+        }
+
+        Poll::Ready(polled)
+    }
+
+    fn poll_trailers(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<headers::HeaderMap>, Self::Error>> {
+        Pin::new(&mut self.inner).poll_trailers(cx)
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -8,4 +8,5 @@
 
 pub mod conditional_requests;
 pub mod content_encoding;
+pub mod loggable;
 pub mod range_requests;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,7 +10,9 @@ mod res;
 mod send;
 mod serve;
 
+use crate::http::loggable::LoggableBody;
+
 pub type Request = hyper::Request<hyper::Body>;
-pub type Response = hyper::Response<hyper::Body>;
+pub type Response = hyper::Response<LoggableBody<hyper::Body>>;
 
 pub use self::serve::{serve, PathType};

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -107,7 +107,10 @@ impl InnerService {
         Ok(self
             .handle_request(self.args.log, remote_addr, &req)
             .await
-            .unwrap_or_else(|_| res::internal_server_error(Response::default())))
+            .unwrap_or_else(|e| {
+                eprintln!("{e:?}");
+                res::internal_server_error(Response::default())
+            }))
     }
 
     /// Construct file path from request path.


### PR DESCRIPTION
closes #96 

- I reverse the logic about content length. We should unset it only when response body is compressed.
- Since response body was polled by hyper, it's too early for us to show log message in original implementation. I implement a "loggable body" to track whether we should print log message.
- I have considered trace in [tower-http](https://github.com/tower-rs/tower-http/blob/0cdef0619d82a3423a3229bcd51238024a8798ab/tower-http/src/trace/mod.rs), but I will have to
  - add tower-http as dependency, which might increase binary size
  - encapsulate my own response to keep log information from request like how I do now
  - comply with tower-http trace signature and lifetime

---

Send request with curl

```
$ curl http://localhost:5000/Cargo.toml
127.0.0.1 - - [24/Sep/2022 16:14:55 +0800] "GET /Cargo.toml HTTP/1.1" 200 1535 "-" "curl/7.68.0" "-"
```

Enable compression and send request with curl

```
$ curl --compressed http://localhost:5000/Cargo.toml
127.0.0.1 - - [24/Sep/2022 16:15:29 +0800] "GET /Cargo.toml HTTP/1.1" 200 859 "-" "curl/7.68.0" "-"
```

Send request with HTTPie

```
$ http http://localhost:5000/Cargo.toml
127.0.0.1 - - [24/Sep/2022 16:16:00 +0800] "GET /Cargo.toml HTTP/1.1" 200 739 "-" "HTTPie/1.0.3" "-"
```

Performance is not compromised

```
$ wrk http://localhost:5000/Cargo.toml
Running 10s test @ http://localhost:5000/Cargo.toml
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.29ms    1.27ms  23.19ms   92.44%
    Req/Sec     4.58k   715.61     5.63k    67.50%
  91141 requests in 10.00s, 156.54MB read
Requests/sec:   9111.59
Transfer/sec:     15.65MB
```

Partial content log

```
$ curl -r 10-20 http://localhost:5000/Cargo.toml
127.0.0.1 - - [24/Sep/2022 16:48:41 +0800] "GET /Cargo.toml HTTP/1.1" 206 11 "-" "curl/7.68.0" "-"
```